### PR TITLE
fix: Auto-tag workflow now triggers PyPI publish directly

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,7 +1,7 @@
 # Auto-tag on version bump merge to main.
 #
 # When a PR is merged to main and pyproject.toml version changed,
-# automatically creates and pushes a git tag to trigger PyPI publish.
+# automatically creates git tag and triggers PyPI publish.
 
 name: Auto Tag Release
 
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -62,3 +63,10 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
           echo "Created and pushed tag: $TAG"
+
+      - name: Trigger PyPI publish
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          gh workflow run publish-pypi.yml --ref v${{ steps.version.outputs.current }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -131,13 +131,14 @@ pip index versions quickcall-supertrace
 
 | Item | Convention |
 |------|------------|
-| Branch name | `release/vX.Y.Z` |
+| Branch name | `release/vX.Y.Z` or `fix/issue-name` or `feat/feature-name` |
 | Commit message | `chore: bump version to X.Y.Z` |
 | PR title | Descriptive goal (e.g., `feat: Add feature X and fix Y`) |
 | PR merge | Squash merge, do NOT delete branch |
 | Issue assignment | Always `@me` |
 | PR assignment | Always `@me` |
 | Issue linking | Use `Closes #X, Closes #Y` in PR body |
+| Branch linking | Link PR to branch in GitHub UI or use `gh pr edit --head <branch>` |
 
 ## Quick Release (One-liner)
 


### PR DESCRIPTION
## Summary

GitHub Actions doesn't trigger workflows on tag pushes from other workflows (security limitation).

## Fix

Auto-tag workflow now uses `gh workflow run` to directly trigger PyPI publish after creating the tag.

## Also Updated

- RELEASE.md: Added branch linking convention
